### PR TITLE
Switch from two `uint64` to a single `complex128` for UUIDs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UUID
 
-## UUID implementation for Go, using a couple `uint64` to represent it.
+## UUID implementation for Go, using a `complex128` to represent it.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 # Usage
 
 ## UUID
-- `Equal` - Check if the given uuid equals.
 - `MarshalBinary` - Marshal the uuid into a byte array.
 - `UnmarshalBinary` - Unmarshal the byte array into uuid.
 - `String` - A string representation of the uuid.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 ## UUID
-### The `*UUID` structure with some methods to work with uuids
+### The `UUID` is underlying a `complex` with methods for UUID.
 
 ---
 
@@ -18,11 +18,11 @@
 - `String` - A string representation of the uuid.
 
 ## V4
-### Generates a new uuid v4 using `math/rand/v2` and returns `*UUID`
+### Generates a new uuid v4 using `math/rand/v2` and returns `UUID`
 ###### New is the same as calling V4
 
 ## V7
-### Generates a new uuid v7 using `time` and `math/rand/v2` and returns `*UUID`
+### Generates a new uuid v7 using `time` and `math/rand/v2` and returns `UUID`
 
 ---
 

--- a/marshal.go
+++ b/marshal.go
@@ -36,8 +36,6 @@ func (uuid *UUID) UnmarshalBinary(data []byte) error {
 		return InvalidLength
 	}
 
-	uuid.a = binary.LittleEndian.Uint64(data[:8])
-	uuid.b = binary.LittleEndian.Uint64(data[8:16])
-
+	*uuid = UUID(complex(float64(binary.LittleEndian.Uint64(data[:8])), float64(binary.LittleEndian.Uint64(data[8:16]))))
 	return nil
 }

--- a/marshal.go
+++ b/marshal.go
@@ -27,8 +27,8 @@ import (
 
 var InvalidLength = errors.New("invalid length")
 
-func (uuid *UUID) MarshalBinary() ([]byte, error) {
-	return binary.LittleEndian.AppendUint64(binary.LittleEndian.AppendUint64(nil, uuid.a), uuid.b), nil
+func (uuid UUID) MarshalBinary() ([]byte, error) {
+	return binary.LittleEndian.AppendUint64(binary.LittleEndian.AppendUint64(nil, uint64(real(uuid))), uint64(imag(uuid))), nil
 }
 
 func (uuid *UUID) UnmarshalBinary(data []byte) error {

--- a/string.go
+++ b/string.go
@@ -34,8 +34,8 @@ func format(num uint64) string {
 	return string(data)
 }
 
-func (uuid *UUID) String() string {
-	s := format(uuid.a) + format(uuid.b)
+func (uuid UUID) String() string {
+	s := format(uint64(real(uuid))) + format(uint64(imag(uuid)))
 	if len(s) != 32 {
 		for i := 0; i < 32-len(s); i++ {
 			s += "0"

--- a/uuid.go
+++ b/uuid.go
@@ -22,14 +22,6 @@ type UUID struct {
 	a, b uint64
 }
 
-func (uuid *UUID) Equal(equal *UUID) bool {
-	if uuid.a == equal.a && uuid.b == equal.b {
-		return true
-	}
-
-	return false
-}
-
 func New() *UUID {
 	return V4()
 }

--- a/uuid.go
+++ b/uuid.go
@@ -18,9 +18,7 @@
 
 package uuid
 
-type UUID struct {
-	a, b uint64
-}
+type UUID complex128
 
 func New() *UUID {
 	return V4()

--- a/uuid.go
+++ b/uuid.go
@@ -20,6 +20,6 @@ package uuid
 
 type UUID complex128
 
-func New() *UUID {
+func New() UUID {
 	return V4()
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -57,12 +57,12 @@ func TestEqual(t *testing.T) {
 	v4 := V4()
 	data, _ := v4.MarshalBinary()
 
-	v42 := new(UUID)
+	v42 := UUID(0)
 	if err := v42.UnmarshalBinary(data); err != nil {
 		t.Errorf("failed to unmarshal uuid: %v", err)
 	}
 
-	if !v4.Equal(v42) {
+	if v4 != v42 {
 		t.Errorf("v4 and v42 does not match: %s vs %s", v4, v42)
 	}
 }
@@ -70,7 +70,7 @@ func TestEqual(t *testing.T) {
 func TestNotEqual(t *testing.T) {
 	t.Parallel()
 
-	if V4().Equal(V4()) {
+	if V4() == V4() {
 		t.Errorf("two random uuids matches")
 	}
 }

--- a/v4.go
+++ b/v4.go
@@ -22,12 +22,9 @@ import (
 	"math/rand/v2"
 )
 
-func V4() *UUID {
-	a := rand.Uint64()
-	b := rand.Uint64()
+func V4() UUID {
+	a := (rand.Uint64() & 0xFFFFFFFFFFFF0FFF) | 0x0000000000004000
+	b := (rand.Uint64() & 0x0FFFFFFFFFFFFFFF) | 0x8000000000000000
 
-	return &UUID{
-		a: (a & 0xFFFFFFFFFFFF0FFF) | 0x0000000000004000,
-		b: (b & 0x0FFFFFFFFFFFFFFF) | 0x8000000000000000,
-	}
+	return UUID(complex(float64(a), float64(b)))
 }

--- a/v7.go
+++ b/v7.go
@@ -23,11 +23,9 @@ import (
 	"time"
 )
 
-func V7() *UUID {
+func V7() UUID {
 	a := uint64(time.Now().UnixNano() / time.Millisecond.Milliseconds())
+	a = (a & 0xFFFFFFFFFFFF0FFF) | 0x0000000000007000
 
-	return &UUID{
-		a: (a & 0xFFFFFFFFFFFF0FFF) | 0x0000000000007000,
-		b: rand.Uint64(),
-	}
+	return UUID(complex(float64(a), float64(rand.Uint64())))
 }


### PR DESCRIPTION
This pull request introduces `complex128` as an UUID. As previously we've managed to make it worked with a simple structure with a couple `uint64` which sums to 128-bit or 32 bytes and interestingly enough `complex128` are 128 bit but here, a struct is not needed nor pointers so thus some bytes in memory are be saved.